### PR TITLE
RenovateBot: change config from ignoreDeps to followTag for React Hooks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,12 @@
 {
   "extends": ["config:base"],
   "automerge": true,
-  "ignoreDeps": ["react", "react-dom"]
+  "packageRules": [
+    {
+      "packageNames": [
+        "react", "react-dom"
+      ],
+      "followTag": "next"
+    }
+  ]
 }


### PR DESCRIPTION
I was just taking a look at the renovatebot options and found [followtag](https://renovatebot.com/docs/configuration-options/#followtag) and also this example [:followTag(<arg0>, <arg1>)](https://renovatebot.com/docs/presets-default/#followtagltarg0gt-ltarg1gt)

Not really an important or relevant issue, but I remembered the react hook issue (https://github.com/benawad/codeponder/issues/112) and shared this PR.
If i understand correctly the definition (I didn't tried it yet), it looks like the "correct" option?